### PR TITLE
Fix potential 'Cannot find module uuid/v4' error

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
         "cordova-plugin-whitelist": "^1.3.4",
         "cordova-plugin-x-toast": "^2.7.2",
         "ionic-plugin-keyboard": "^2.2.1",
-        "phonegap-plugin-barcodescanner": "^8.1.0"
+        "phonegap-plugin-barcodescanner": "^8.1.0",
+        "uuid": "3.2.1"
     },
     "devDependencies": {
         "@ionic/v1-toolkit": "2.0.18",

--- a/www/js/config.js
+++ b/www/js/config.js
@@ -51,7 +51,7 @@ angular.module("cesium.config", [])
 		}
 	},
 	"version": "1.1.5",
-	"build": "2020-02-06T18:09:23.262Z",
+	"build": "2020-02-07T07:17:01.084Z",
 	"newIssueUrl": "https://github.com/duniter-gchange/gchange-client/issues/new?labels=bug"
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10579,6 +10579,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
+uuid@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+  integrity sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
+
 uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"


### PR DESCRIPTION
'Cannot find module uuid/v4' error may appear after a 'ionic cordova platform add' command. The fix consist of including the compatible uuid dependency directly in the package.json